### PR TITLE
修改下包含在<code></code>中的样式

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -45,7 +45,7 @@ h2 {font-size:22px;font-weight:bold;margin-bottom:25px;}
 h3 {font-size:18px;font-weight:bold;margin-bottom:25px;}
 h4,h5,h6 {font-weight:bold;margin-bottom:15px;}
 p {margin-bottom:40px;line-height:1.8em;}
-code {background:#eee;border:1px solid #ccc;padding:0 5px;font-family:"Courier";line-height:14px;font-size:14px;word-wrap:break-word; }
+code {background:#f8f8f8;border:1px solid #ddd;padding:0 5px;margin:0 2px;border-radius:3px;font-family:"Courier";line-height:14px;font-size:14px;word-wrap:break-word; }
 pre {background-color:#000;padding:15px;overflow:auto;margin-bottom:40px;font-size:14px;border: 1px solid #eee;-webkit-border-radius: 4px 4px 4px 4px;-moz-border-radius: 4px 4px 4px 4px;border-radius: 4px 4px 4px 4px;color:#b9bdb6;margin-top:-20px; }
 h4+pre, h3+pre { margin-top:20px; }
 pre code{background-color:transparent;border:none;padding:0;word-wrap:normal;}


### PR DESCRIPTION
原来的看起来和中文太紧密，修改了下(参考了github中使用``显示代码的CSS)

原来的
![_2013-09-06_18-24-08](https://f.cloud.github.com/assets/1575056/1095185/7127eef2-16df-11e3-936d-16d7514c3e31.png)

现在的
![_2013-09-06_18-23-38](https://f.cloud.github.com/assets/1575056/1095190/7f37d84a-16df-11e3-9130-c7cc6cd4fee7.png)
